### PR TITLE
reorg with better namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Install-Package MerkleTree
 ### In-Memory Merkle Tree
 
 ```csharp
-using MerkleTree;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
 using System.Text;
 
 // Create leaf data from your input
@@ -77,7 +78,8 @@ var treeSHA512 = new MerkleTree(leafData, new Sha512HashFunction());
 For large datasets that don't fit in memory, use the streaming builder:
 
 ```csharp
-using MerkleTree;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
 using System.Text;
 
 // Create a builder
@@ -223,7 +225,8 @@ The library provides deterministic binary serialization for Merkle tree roots, e
 ### Basic Usage
 
 ```csharp
-using MerkleTree;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
 using System.Text;
 
 var leafData = new List<byte[]>
@@ -286,6 +289,10 @@ The serialization format is simply the raw hash bytes, providing minimal overhea
 Generate and verify Merkle proofs to prove that a specific leaf is part of the tree:
 
 ```csharp
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+
 var tree = new MerkleTree(leafData);
 var proof = tree.GenerateProof(leafIndex: 1);
 

--- a/docs/PROOF_GENERATION.md
+++ b/docs/PROOF_GENERATION.md
@@ -15,7 +15,9 @@ Merkle proofs allow verification that a specific leaf is part of a Merkle tree w
 For in-memory trees, proof generation is straightforward and efficient:
 
 ```csharp
-using MerkleTree;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
 using System.Text;
 
 var leafData = new List<byte[]>
@@ -62,6 +64,10 @@ The `GenerateProof` method uses an **optimized approach that only computes O(log
 - Memory usage: O(log n) instead of O(n)
 
 ```csharp
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+
 var builder = new MerkleTreeStream();
 
 // You need to know the leaf count beforehand
@@ -148,6 +154,8 @@ A `MerkleProof` object contains:
 To verify a proof:
 
 ```csharp
+using MerkleTree.Hashing;
+
 var hashFunction = new Sha256HashFunction();
 bool isValid = proof.Verify(expectedRootHash, hashFunction);
 ```
@@ -199,7 +207,9 @@ Common exceptions:
 ## Example: Complete Workflow
 
 ```csharp
-using MerkleTree;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
 using System.Text;
 
 // 1. Prepare data

--- a/docs/STREAMING.md
+++ b/docs/STREAMING.md
@@ -11,6 +11,8 @@ The `MerkleTreeStream` class enables building Merkle trees from datasets that ex
 ### 1. Multiple Input Methods
 
 ```csharp
+using MerkleTree.Core;
+
 var builder = new MerkleTreeStream();
 
 // Synchronous streaming
@@ -35,6 +37,8 @@ var metadata3 = builder.BuildInBatches(IEnumerable<byte[]> leaves, int batchSize
 The streaming builder produces identical root hashes to the in-memory `MerkleTree` class:
 
 ```csharp
+using MerkleTree.Core;
+
 var leafData = GetLeaves();
 
 // Streaming approach
@@ -89,6 +93,8 @@ This ensures:
 Process multi-gigabyte files with fixed-size records:
 
 ```csharp
+using MerkleTree.Core;
+
 IEnumerable<byte[]> ReadFileRecords(string path, int recordSize)
 {
     using var stream = File.OpenRead(path);
@@ -110,6 +116,8 @@ var metadata = builder.BuildInBatches(records, batchSize: 1000);
 Build trees from database results without loading all rows:
 
 ```csharp
+using MerkleTree.Core;
+
 async IAsyncEnumerable<byte[]> StreamDatabaseRecords(DbConnection conn)
 {
     await using var cmd = conn.CreateCommand();
@@ -132,6 +140,8 @@ var metadata = await builder.BuildAsync(records);
 Process data as it arrives over the network:
 
 ```csharp
+using MerkleTree.Core;
+
 async IAsyncEnumerable<byte[]> StreamNetworkData(Stream networkStream)
 {
     var buffer = new byte[32];
@@ -191,6 +201,9 @@ All tests verify that streaming produces identical results to the in-memory impl
 ### MerkleTreeStream
 
 ```csharp
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+
 public class MerkleTreeStream
 {
     // Constructor
@@ -210,6 +223,8 @@ public class MerkleTreeStream
 ### MerkleTreeMetadata
 
 ```csharp
+using MerkleTree.Core;
+
 public class MerkleTreeMetadata
 {
     // Constructor
@@ -226,6 +241,8 @@ public class MerkleTreeMetadata
 ### MerkleTree
 
 ```csharp
+using MerkleTree.Core;
+
 public class MerkleTree
 {
     // Get metadata from an in-memory tree

--- a/src/MerkleTree/Core/MerkleTree.cs
+++ b/src/MerkleTree/Core/MerkleTree.cs
@@ -1,4 +1,7 @@
-namespace MerkleTree;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+
+namespace MerkleTree.Core;
 
 /// <summary>
 /// Represents a binary Merkle tree structure with support for non-power-of-two leaf counts.

--- a/src/MerkleTree/Core/MerkleTreeBase.cs
+++ b/src/MerkleTree/Core/MerkleTreeBase.cs
@@ -1,4 +1,6 @@
-namespace MerkleTree;
+using MerkleTree.Hashing;
+
+namespace MerkleTree.Core;
 
 /// <summary>
 /// Base class providing shared functionality for Merkle tree construction.

--- a/src/MerkleTree/Core/MerkleTreeMetadata.cs
+++ b/src/MerkleTree/Core/MerkleTreeMetadata.cs
@@ -1,4 +1,4 @@
-namespace MerkleTree;
+namespace MerkleTree.Core;
 
 /// <summary>
 /// Contains metadata about a constructed Merkle tree.

--- a/src/MerkleTree/Core/MerkleTreeNode.cs
+++ b/src/MerkleTree/Core/MerkleTreeNode.cs
@@ -1,4 +1,4 @@
-namespace MerkleTree;
+namespace MerkleTree.Core;
 
 /// <summary>
 /// Represents a node in a Merkle tree structure.

--- a/src/MerkleTree/Core/MerkleTreeStream.cs
+++ b/src/MerkleTree/Core/MerkleTreeStream.cs
@@ -1,4 +1,7 @@
-namespace MerkleTree;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+
+namespace MerkleTree.Core;
 
 /// <summary>
 /// Builds Merkle trees from streaming/chunked input without requiring the entire dataset in memory.

--- a/src/MerkleTree/Hashing/Blake3HashFunction.cs
+++ b/src/MerkleTree/Hashing/Blake3HashFunction.cs
@@ -2,7 +2,7 @@
 using Blake3;
 #endif
 
-namespace MerkleTree;
+namespace MerkleTree.Hashing;
 
 #if NET10_0_OR_GREATER
 /// <summary>

--- a/src/MerkleTree/Hashing/IHashFunction.cs
+++ b/src/MerkleTree/Hashing/IHashFunction.cs
@@ -1,4 +1,4 @@
-namespace MerkleTree;
+namespace MerkleTree.Hashing;
 
 /// <summary>
 /// Defines an abstraction for cryptographic hash functions used in Merkle tree construction.

--- a/src/MerkleTree/Hashing/Sha256HashFunction.cs
+++ b/src/MerkleTree/Hashing/Sha256HashFunction.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
 
-namespace MerkleTree;
+namespace MerkleTree.Hashing;
 
 /// <summary>
 /// SHA-256 hash function implementation using System.Security.Cryptography.

--- a/src/MerkleTree/Hashing/Sha512HashFunction.cs
+++ b/src/MerkleTree/Hashing/Sha512HashFunction.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
 
-namespace MerkleTree;
+namespace MerkleTree.Hashing;
 
 /// <summary>
 /// SHA-512 hash function implementation using System.Security.Cryptography.

--- a/src/MerkleTree/Proofs/MerkleProof.cs
+++ b/src/MerkleTree/Proofs/MerkleProof.cs
@@ -1,4 +1,6 @@
-namespace MerkleTree;
+using MerkleTree.Hashing;
+
+namespace MerkleTree.Proofs;
 
 /// <summary>
 /// Represents a Merkle proof that can be used to verify a leaf's inclusion in a Merkle tree.

--- a/tests/MerkleTree.Tests/Core/MerkleTreeStreamTests.cs
+++ b/tests/MerkleTree.Tests/Core/MerkleTreeStreamTests.cs
@@ -1,6 +1,9 @@
 using System.Text;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTreeClass = MerkleTree.Core.MerkleTree;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Core;
 
 /// <summary>
 /// Tests for the MerkleTreeBuilder class, focusing on streaming/chunked input support.
@@ -130,7 +133,7 @@ public class MerkleTreeStreamTests
 
         // Act
         var asyncMetadata = await builder.BuildAsync(leafDataAsync);
-        var originalTree = new MerkleTree(leafDataSync);
+        var originalTree = new MerkleTreeClass(leafDataSync);
         var originalRootHash = originalTree.GetRootHash();
 
         // Assert

--- a/tests/MerkleTree.Tests/Core/MerkleTreeTests.cs
+++ b/tests/MerkleTree.Tests/Core/MerkleTreeTests.cs
@@ -1,8 +1,11 @@
 using System.Security.Cryptography;
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+using MerkleTreeClass = MerkleTree.Core.MerkleTree;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Core;
 
 /// <summary>
 /// Tests for the MerkleTree class, focusing on non-power-of-two leaf support
@@ -31,7 +34,7 @@ public class MerkleTreeTests
     public void Constructor_WithNullLeafData_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new MerkleTree(null!));
+        Assert.Throws<ArgumentNullException>(() => new MerkleTreeClass(null!));
     }
 
     [Fact]
@@ -41,7 +44,7 @@ public class MerkleTreeTests
         var emptyData = new List<byte[]>();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new MerkleTree(emptyData));
+        Assert.Throws<ArgumentException>(() => new MerkleTreeClass(emptyData));
     }
 
     [Fact]
@@ -51,7 +54,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -67,7 +70,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1", "leaf2");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -91,7 +94,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -126,7 +129,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3", "leaf4");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -151,7 +154,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3", "leaf4", "leaf5");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -174,8 +177,8 @@ public class MerkleTreeTests
         var leafData2 = CreateLeafData("leaf1", "leaf2", "leaf3");
 
         // Act
-        var tree1 = new MerkleTree(leafData1);
-        var tree2 = new MerkleTree(leafData2);
+        var tree1 = new MerkleTreeClass(leafData1);
+        var tree2 = new MerkleTreeClass(leafData2);
         var hash1 = tree1.GetRootHash();
         var hash2 = tree2.GetRootHash();
 
@@ -191,8 +194,8 @@ public class MerkleTreeTests
         var leafData2 = CreateLeafData("leaf1", "leaf2", "leaf4");
 
         // Act
-        var tree1 = new MerkleTree(leafData1);
-        var tree2 = new MerkleTree(leafData2);
+        var tree1 = new MerkleTreeClass(leafData1);
+        var tree2 = new MerkleTreeClass(leafData2);
         var hash1 = tree1.GetRootHash();
         var hash2 = tree2.GetRootHash();
 
@@ -208,8 +211,8 @@ public class MerkleTreeTests
         var leafData2 = CreateLeafData("leaf2", "leaf1");
 
         // Act
-        var tree1 = new MerkleTree(leafData1);
-        var tree2 = new MerkleTree(leafData2);
+        var tree1 = new MerkleTreeClass(leafData1);
+        var tree2 = new MerkleTreeClass(leafData2);
         var hash1 = tree1.GetRootHash();
         var hash2 = tree2.GetRootHash();
 
@@ -224,8 +227,8 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("leaf1", "leaf2");
 
         // Act
-        var treeSHA256 = new MerkleTree(leafData, new Sha256HashFunction());
-        var treeSHA512 = new MerkleTree(leafData, new Sha512HashFunction());
+        var treeSHA256 = new MerkleTreeClass(leafData, new Sha256HashFunction());
+        var treeSHA512 = new MerkleTreeClass(leafData, new Sha512HashFunction());
 
         // Assert
         Assert.Equal("SHA-256", treeSHA256.HashFunction.Name);
@@ -240,7 +243,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("l1", "l2", "l3", "l4", "l5", "l6", "l7");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -259,7 +262,7 @@ public class MerkleTreeTests
         var leafData = CreateLeafData("l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8");
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.Root);
@@ -287,8 +290,8 @@ public class MerkleTreeTests
             .ToList();
 
         // Act
-        var tree1 = new MerkleTree(leafData);
-        var tree2 = new MerkleTree(leafData);
+        var tree1 = new MerkleTreeClass(leafData);
+        var tree2 = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.Equal(tree1.GetRootHash(), tree2.GetRootHash());
@@ -305,7 +308,7 @@ public class MerkleTreeTests
 
         // Act - build tree multiple times
         var trees = Enumerable.Range(0, 10)
-            .Select(_ => new MerkleTree(leafData.Select(d => d.ToArray()).ToList()))
+            .Select(_ => new MerkleTreeClass(leafData.Select(d => d.ToArray()).ToList()))
             .ToList();
 
         // Assert - all trees should have identical root hashes
@@ -325,13 +328,13 @@ public class MerkleTreeTests
 
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var rootHash = tree.GetRootHash();
 
         // If we were duplicating the last leaf, the tree with 4 leaves where
         // the last two are identical should produce the same hash
         var leafDataWithDuplication = CreateLeafData("leaf1", "leaf2", "leaf3", "leaf3");
-        var treeWithDuplication = new MerkleTree(leafDataWithDuplication);
+        var treeWithDuplication = new MerkleTreeClass(leafDataWithDuplication);
         var hashWithDuplication = treeWithDuplication.GetRootHash();
 
         // Assert - these should be different because we use padding, not duplication
@@ -343,7 +346,7 @@ public class MerkleTreeTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var metadata = tree.GetMetadata();
@@ -361,7 +364,7 @@ public class MerkleTreeTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var metadata = tree.GetMetadata();
@@ -377,7 +380,7 @@ public class MerkleTreeTests
     {
         // Arrange
         var leafData = CreateLeafData("l1", "l2", "l3", "l4");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var metadata = tree.GetMetadata();

--- a/tests/MerkleTree.Tests/Core/RootSerializationTests.cs
+++ b/tests/MerkleTree.Tests/Core/RootSerializationTests.cs
@@ -1,7 +1,10 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Core;
+using MerkleTree.Hashing;
+using MerkleTreeClass = MerkleTree.Core.MerkleTree;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Core;
 
 /// <summary>
 /// Tests for root serialization and deserialization functionality.
@@ -21,7 +24,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2", "test3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var root = tree.Root;
 
         // Act
@@ -38,8 +41,8 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1", "data2", "data3");
-        var tree1 = new MerkleTree(leafData);
-        var tree2 = new MerkleTree(leafData);
+        var tree1 = new MerkleTreeClass(leafData);
+        var tree2 = new MerkleTreeClass(leafData);
 
         // Act
         var serialized1 = tree1.Root.Serialize();
@@ -64,7 +67,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var originalHash = tree.GetRootHash();
 
         // Act
@@ -98,7 +101,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1", "data2", "data3", "data4");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var originalRoot = tree.Root;
 
         // Act
@@ -114,9 +117,9 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2");
-        var treeSha256 = new MerkleTree(leafData, new Sha256HashFunction());
-        var treeSha512 = new MerkleTree(leafData, new Sha512HashFunction());
-        var treeBlake3 = new MerkleTree(leafData, new Blake3HashFunction());
+        var treeSha256 = new MerkleTreeClass(leafData, new Sha256HashFunction());
+        var treeSha512 = new MerkleTreeClass(leafData, new Sha512HashFunction());
+        var treeBlake3 = new MerkleTreeClass(leafData, new Blake3HashFunction());
 
         // Act
         var serializedSha256 = treeSha256.Root.Serialize();
@@ -141,7 +144,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1", "data2");
-        var tree = new MerkleTree(leafData, new Sha512HashFunction());
+        var tree = new MerkleTreeClass(leafData, new Sha512HashFunction());
         var originalRoot = tree.Root;
 
         // Act
@@ -158,7 +161,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1", "data2", "data3");
-        var tree = new MerkleTree(leafData, new Blake3HashFunction());
+        var tree = new MerkleTreeClass(leafData, new Blake3HashFunction());
         var originalRoot = tree.Root;
 
         // Act
@@ -175,7 +178,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2", "test3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var root = tree.Root;
 
         // Act
@@ -193,7 +196,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var originalHash = tree.GetRootHash();
 
         // Act
@@ -211,7 +214,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var metadata = tree.GetMetadata();
 
         // Act
@@ -228,7 +231,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("test1", "test2", "test3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var metadata = tree.GetMetadata();
         var serialized = metadata.SerializeRoot();
 
@@ -245,7 +248,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("data1", "data2", "data3", "data4", "data5");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var metadata = tree.GetMetadata();
 
         // Act
@@ -261,7 +264,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("single");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var serialized = tree.Root.Serialize();
@@ -277,7 +280,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("a", "b", "c", "d", "e", "f", "g");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var serialized = tree.Root.Serialize();
@@ -293,7 +296,7 @@ public class RootSerializationTests
     {
         // Arrange
         var leafData = CreateLeafData("1", "2", "3", "4", "5", "6", "7", "8");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var serialized = tree.Root.Serialize();

--- a/tests/MerkleTree.Tests/Hashing/Blake3HashFunctionTests.cs
+++ b/tests/MerkleTree.Tests/Hashing/Blake3HashFunctionTests.cs
@@ -1,12 +1,13 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Hashing;
 
 /// <summary>
-/// Tests for the Sha256HashFunction class.
+/// Tests for the Blake3HashFunction class.
 /// </summary>
-public class Sha256HashFunctionTests
+public class Blake3HashFunctionTests
 {
     /// <summary>
     /// Helper method to create test data.
@@ -17,23 +18,23 @@ public class Sha256HashFunctionTests
     }
 
     [Fact]
-    public void Name_ReturnsSHA256()
+    public void Name_ReturnsBLAKE3()
     {
         // Arrange
-        var hashFunction = new Sha256HashFunction();
+        var hashFunction = new Blake3HashFunction();
 
         // Act
         var name = hashFunction.Name;
 
         // Assert
-        Assert.Equal("SHA-256", name);
+        Assert.Equal("BLAKE3", name);
     }
 
     [Fact]
     public void HashSizeInBytes_Returns32()
     {
         // Arrange
-        var hashFunction = new Sha256HashFunction();
+        var hashFunction = new Blake3HashFunction();
 
         // Act
         var size = hashFunction.HashSizeInBytes;
@@ -42,11 +43,12 @@ public class Sha256HashFunctionTests
         Assert.Equal(32, size);
     }
 
+#if NET10_0_OR_GREATER
     [Fact]
     public void ComputeHash_ProducesDeterministicOutput()
     {
         // Arrange
-        var hashFunction = new Sha256HashFunction();
+        var hashFunction = new Blake3HashFunction();
         var data = CreateTestData("test data");
 
         // Act
@@ -62,7 +64,7 @@ public class Sha256HashFunctionTests
     public void ComputeHash_DifferentDataProducesDifferentHash()
     {
         // Arrange
-        var hashFunction = new Sha256HashFunction();
+        var hashFunction = new Blake3HashFunction();
         var data1 = CreateTestData("test data 1");
         var data2 = CreateTestData("test data 2");
 
@@ -75,10 +77,28 @@ public class Sha256HashFunctionTests
     }
 
     [Fact]
+    public void ComputeHash_ProducesDifferentHashThanSha256()
+    {
+        // Arrange
+        var sha256 = new Sha256HashFunction();
+        var blake3 = new Blake3HashFunction();
+        var data = CreateTestData("test data");
+
+        // Act
+        var sha256Hash = sha256.ComputeHash(data);
+        var blake3Hash = blake3.ComputeHash(data);
+
+        // Assert
+        Assert.NotEqual(sha256Hash, blake3Hash);
+        Assert.Equal(32, sha256Hash.Length);
+        Assert.Equal(32, blake3Hash.Length);
+    }
+
+    [Fact]
     public void ComputeHash_ReturnsCorrectLength()
     {
         // Arrange
-        var hashFunction = new Sha256HashFunction();
+        var hashFunction = new Blake3HashFunction();
         var data = CreateTestData("test");
 
         // Act
@@ -87,4 +107,16 @@ public class Sha256HashFunctionTests
         // Assert
         Assert.Equal(hashFunction.HashSizeInBytes, hash.Length);
     }
+#else
+    [Fact]
+    public void ComputeHash_ThrowsPlatformNotSupportedOnNetStandard21()
+    {
+        // Arrange
+        var hashFunction = new Blake3HashFunction();
+        var data = CreateTestData("test data");
+
+        // Act & Assert
+        Assert.Throws<PlatformNotSupportedException>(() => hashFunction.ComputeHash(data));
+    }
+#endif
 }

--- a/tests/MerkleTree.Tests/Hashing/IHashFunctionTests.cs
+++ b/tests/MerkleTree.Tests/Hashing/IHashFunctionTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
+using MerkleTreeClass = MerkleTree.Core.MerkleTree;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Hashing;
 
 /// <summary>
 /// Tests for the IHashFunction interface.
@@ -40,7 +42,7 @@ public class IHashFunctionTests
         };
 
         // Act
-        var tree = new MerkleTree(leafData, hashFunction);
+        var tree = new MerkleTreeClass(leafData, hashFunction);
 
         // Assert
         Assert.NotNull(tree.HashFunction);
@@ -61,7 +63,7 @@ public class IHashFunctionTests
         };
 
         // Act
-        var tree = new MerkleTree(leafData, hashFunction);
+        var tree = new MerkleTreeClass(leafData, hashFunction);
 
         // Assert
         Assert.NotNull(tree.HashFunction);
@@ -83,8 +85,8 @@ public class IHashFunctionTests
         };
 
         // Act
-        var treeSha256 = new MerkleTree(leafData, sha256);
-        var treeBlake3 = new MerkleTree(leafData, blake3);
+        var treeSha256 = new MerkleTreeClass(leafData, sha256);
+        var treeBlake3 = new MerkleTreeClass(leafData, blake3);
 
         // Assert
         Assert.NotEqual(treeSha256.GetRootHash(), treeBlake3.GetRootHash());
@@ -102,7 +104,7 @@ public class IHashFunctionTests
         };
 
         // Act
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Assert
         Assert.NotNull(tree.HashFunction);
@@ -126,8 +128,8 @@ public class IHashFunctionTests
         };
 
         // Act - Create trees with different hash functions
-        var tree1 = new MerkleTree(leafData, sha256);
-        var tree2 = new MerkleTree(leafData, sha256);
+        var tree1 = new MerkleTreeClass(leafData, sha256);
+        var tree2 = new MerkleTreeClass(leafData, sha256);
 
         // Assert - Same hash function produces same results
         Assert.Equal(tree1.GetRootHash(), tree2.GetRootHash());

--- a/tests/MerkleTree.Tests/Hashing/Sha256HashFunctionTests.cs
+++ b/tests/MerkleTree.Tests/Hashing/Sha256HashFunctionTests.cs
@@ -1,12 +1,13 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Hashing;
 
 /// <summary>
-/// Tests for the Sha512HashFunction class.
+/// Tests for the Sha256HashFunction class.
 /// </summary>
-public class Sha512HashFunctionTests
+public class Sha256HashFunctionTests
 {
     /// <summary>
     /// Helper method to create test data.
@@ -17,36 +18,36 @@ public class Sha512HashFunctionTests
     }
 
     [Fact]
-    public void Name_ReturnsSHA512()
+    public void Name_ReturnsSHA256()
     {
         // Arrange
-        var hashFunction = new Sha512HashFunction();
+        var hashFunction = new Sha256HashFunction();
 
         // Act
         var name = hashFunction.Name;
 
         // Assert
-        Assert.Equal("SHA-512", name);
+        Assert.Equal("SHA-256", name);
     }
 
     [Fact]
-    public void HashSizeInBytes_Returns64()
+    public void HashSizeInBytes_Returns32()
     {
         // Arrange
-        var hashFunction = new Sha512HashFunction();
+        var hashFunction = new Sha256HashFunction();
 
         // Act
         var size = hashFunction.HashSizeInBytes;
 
         // Assert
-        Assert.Equal(64, size);
+        Assert.Equal(32, size);
     }
 
     [Fact]
     public void ComputeHash_ProducesDeterministicOutput()
     {
         // Arrange
-        var hashFunction = new Sha512HashFunction();
+        var hashFunction = new Sha256HashFunction();
         var data = CreateTestData("test data");
 
         // Act
@@ -55,14 +56,14 @@ public class Sha512HashFunctionTests
 
         // Assert
         Assert.Equal(hash1, hash2);
-        Assert.Equal(64, hash1.Length);
+        Assert.Equal(32, hash1.Length);
     }
 
     [Fact]
     public void ComputeHash_DifferentDataProducesDifferentHash()
     {
         // Arrange
-        var hashFunction = new Sha512HashFunction();
+        var hashFunction = new Sha256HashFunction();
         var data1 = CreateTestData("test data 1");
         var data2 = CreateTestData("test data 2");
 
@@ -78,7 +79,7 @@ public class Sha512HashFunctionTests
     public void ComputeHash_ReturnsCorrectLength()
     {
         // Arrange
-        var hashFunction = new Sha512HashFunction();
+        var hashFunction = new Sha256HashFunction();
         var data = CreateTestData("test");
 
         // Act

--- a/tests/MerkleTree.Tests/Hashing/Sha512HashFunctionTests.cs
+++ b/tests/MerkleTree.Tests/Hashing/Sha512HashFunctionTests.cs
@@ -1,12 +1,13 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Hashing;
 
 /// <summary>
-/// Tests for the Blake3HashFunction class.
+/// Tests for the Sha512HashFunction class.
 /// </summary>
-public class Blake3HashFunctionTests
+public class Sha512HashFunctionTests
 {
     /// <summary>
     /// Helper method to create test data.
@@ -17,37 +18,36 @@ public class Blake3HashFunctionTests
     }
 
     [Fact]
-    public void Name_ReturnsBLAKE3()
+    public void Name_ReturnsSHA512()
     {
         // Arrange
-        var hashFunction = new Blake3HashFunction();
+        var hashFunction = new Sha512HashFunction();
 
         // Act
         var name = hashFunction.Name;
 
         // Assert
-        Assert.Equal("BLAKE3", name);
+        Assert.Equal("SHA-512", name);
     }
 
     [Fact]
-    public void HashSizeInBytes_Returns32()
+    public void HashSizeInBytes_Returns64()
     {
         // Arrange
-        var hashFunction = new Blake3HashFunction();
+        var hashFunction = new Sha512HashFunction();
 
         // Act
         var size = hashFunction.HashSizeInBytes;
 
         // Assert
-        Assert.Equal(32, size);
+        Assert.Equal(64, size);
     }
 
-#if NET10_0_OR_GREATER
     [Fact]
     public void ComputeHash_ProducesDeterministicOutput()
     {
         // Arrange
-        var hashFunction = new Blake3HashFunction();
+        var hashFunction = new Sha512HashFunction();
         var data = CreateTestData("test data");
 
         // Act
@@ -56,14 +56,14 @@ public class Blake3HashFunctionTests
 
         // Assert
         Assert.Equal(hash1, hash2);
-        Assert.Equal(32, hash1.Length);
+        Assert.Equal(64, hash1.Length);
     }
 
     [Fact]
     public void ComputeHash_DifferentDataProducesDifferentHash()
     {
         // Arrange
-        var hashFunction = new Blake3HashFunction();
+        var hashFunction = new Sha512HashFunction();
         var data1 = CreateTestData("test data 1");
         var data2 = CreateTestData("test data 2");
 
@@ -76,28 +76,10 @@ public class Blake3HashFunctionTests
     }
 
     [Fact]
-    public void ComputeHash_ProducesDifferentHashThanSha256()
-    {
-        // Arrange
-        var sha256 = new Sha256HashFunction();
-        var blake3 = new Blake3HashFunction();
-        var data = CreateTestData("test data");
-
-        // Act
-        var sha256Hash = sha256.ComputeHash(data);
-        var blake3Hash = blake3.ComputeHash(data);
-
-        // Assert
-        Assert.NotEqual(sha256Hash, blake3Hash);
-        Assert.Equal(32, sha256Hash.Length);
-        Assert.Equal(32, blake3Hash.Length);
-    }
-
-    [Fact]
     public void ComputeHash_ReturnsCorrectLength()
     {
         // Arrange
-        var hashFunction = new Blake3HashFunction();
+        var hashFunction = new Sha512HashFunction();
         var data = CreateTestData("test");
 
         // Act
@@ -106,16 +88,4 @@ public class Blake3HashFunctionTests
         // Assert
         Assert.Equal(hashFunction.HashSizeInBytes, hash.Length);
     }
-#else
-    [Fact]
-    public void ComputeHash_ThrowsPlatformNotSupportedOnNetStandard21()
-    {
-        // Arrange
-        var hashFunction = new Blake3HashFunction();
-        var data = CreateTestData("test data");
-
-        // Act & Assert
-        Assert.Throws<PlatformNotSupportedException>(() => hashFunction.ComputeHash(data));
-    }
-#endif
 }

--- a/tests/MerkleTree.Tests/Proofs/MerkleProofTests.cs
+++ b/tests/MerkleTree.Tests/Proofs/MerkleProofTests.cs
@@ -1,7 +1,10 @@
 using System.Text;
 using Xunit;
+using MerkleTree.Hashing;
+using MerkleTree.Proofs;
+using MerkleTreeClass = MerkleTree.Core.MerkleTree;
 
-namespace MerkleTree.Tests;
+namespace MerkleTree.Tests.Proofs;
 
 /// <summary>
 /// Tests for Merkle proof generation and verification.
@@ -21,7 +24,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act
         var proof = tree.GenerateProof(0);
@@ -40,7 +43,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act - Generate proof for first leaf
         var proof0 = tree.GenerateProof(0);
@@ -70,7 +73,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act - Generate proof for first leaf
         var proof0 = tree.GenerateProof(0);
@@ -108,7 +111,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3", "leaf4");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act & Assert - Generate proofs for all leaves
         for (int i = 0; i < 4; i++)
@@ -127,7 +130,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("l1", "l2", "l3", "l4", "l5", "l6", "l7");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act & Assert - Generate proofs for all leaves
         for (int i = 0; i < 7; i++)
@@ -146,7 +149,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => tree.GenerateProof(-1));
@@ -159,7 +162,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var rootHash = tree.GetRootHash();
         var hashFunction = new Sha256HashFunction();
 
@@ -179,7 +182,7 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var rootHash = tree.GetRootHash();
         var hashFunction = new Sha256HashFunction();
 
@@ -205,10 +208,10 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData1 = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var tree1 = new MerkleTree(leafData1);
+        var tree1 = new MerkleTreeClass(leafData1);
         
         var leafData2 = CreateLeafData("leaf4", "leaf5", "leaf6");
-        var tree2 = new MerkleTree(leafData2);
+        var tree2 = new MerkleTreeClass(leafData2);
         
         var hashFunction = new Sha256HashFunction();
 
@@ -225,8 +228,8 @@ public class MerkleProofTests
     {
         // Arrange
         var leafData = CreateLeafData("leaf1", "leaf2", "leaf3");
-        var treeSHA256 = new MerkleTree(leafData, new Sha256HashFunction());
-        var treeSHA512 = new MerkleTree(leafData, new Sha512HashFunction());
+        var treeSHA256 = new MerkleTreeClass(leafData, new Sha256HashFunction());
+        var treeSHA512 = new MerkleTreeClass(leafData, new Sha512HashFunction());
 
         // Act - Generate proof from SHA256 tree
         var proof = treeSHA256.GenerateProof(1);
@@ -249,7 +252,7 @@ public class MerkleProofTests
         var leafData = Enumerable.Range(0, 100)
             .Select(i => Encoding.UTF8.GetBytes($"leaf{i}"))
             .ToList();
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
         var rootHash = tree.GetRootHash();
         var hashFunction = new Sha256HashFunction();
 
@@ -380,7 +383,7 @@ public class MerkleProofTests
     {
         // Arrange - Tree with 4 leaves has predictable structure
         var leafData = CreateLeafData("leaf0", "leaf1", "leaf2", "leaf3");
-        var tree = new MerkleTree(leafData);
+        var tree = new MerkleTreeClass(leafData);
 
         // Act - Generate proofs
         var proof0 = tree.GenerateProof(0); // Left child at both levels


### PR DESCRIPTION
This pull request reorganizes the Merkle tree library into a more modular structure by splitting it into themed namespaces (`Core`, `Hashing`, and `Proofs`) and updating all references throughout the codebase and documentation. The changes improve code clarity, maintainability, and extensibility, making it easier to work with different components of the library and to add new features in the future.

**Codebase modularization and namespace refactoring:**

* Core Merkle tree implementation files (`MerkleTree.cs`, `MerkleTreeBase.cs`, `MerkleTreeMetadata.cs`, `MerkleTreeNode.cs`, `MerkleTreeStream.cs`) were moved into the new `MerkleTree.Core` namespace, with necessary `using` directives added for hashing and proofs. [[1]](diffhunk://#diff-17571c520cc9e7b7bc6c5f7aef213cf279db21dd3876431d44f61d358f03d236L1-R4) [[2]](diffhunk://#diff-77cf0510b67739cbfba894c76dca08e552c2405eaef434601fab9ee550846891L1-R3) [[3]](diffhunk://#diff-e8b43f5ac780f65dab824d50d33ba6c660d0d9433b6e6a7b4cc1b656034104a7L1-R1) [[4]](diffhunk://#diff-107c0f2af62e0d44d760e73facf1641d3ce165d52e8cb7abc5a74984d56ad2b5L1-R1) [[5]](diffhunk://#diff-db4bcf9ca787c2ab0c4d7d69ec619332498992535d3ae6a58d94cb320b2ac0cdL1-R4)
* Hash function implementations (`Sha256HashFunction.cs`, `Sha512HashFunction.cs`, `Blake3HashFunction.cs`, `IHashFunction.cs`) were moved into the new `MerkleTree.Hashing` namespace. [[1]](diffhunk://#diff-25488354f6d8baff44564dbf1a958b8800d4a9dc282fc8305764511de4fb9701L5-R5) [[2]](diffhunk://#diff-303d9becbdcb191bdaceadfb357e180e307197df0996538ed8d654128e10f643L1-R1) [[3]](diffhunk://#diff-c884b40769bac079c8c1a8c8bf59b651f1ca9c92bdc606643ac5b1624c02a9a7L3-R3) [[4]](diffhunk://#diff-924256a50b3615d499a4f9e84394d7e0a3959e11f23c553716bb339f1669b7a1L3-R3)
* Merkle proof logic was moved into the new `MerkleTree.Proofs` namespace.

**Test suite updates:**

* Test files were moved into corresponding subfolders and namespaces, and updated to use the new class locations and namespaced references (`MerkleTreeClass`, `MerkleTree.Hashing`, `MerkleTree.Proofs`). [[1]](diffhunk://#diff-6217a10489dd2a6c1ec225bb39f79429072b2a7cca96d34b56672418660f12d6R2-R6) [[2]](diffhunk://#diff-6217a10489dd2a6c1ec225bb39f79429072b2a7cca96d34b56672418660f12d6L133-R136) [[3]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6R4-R8) [[4]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L34-R37) [[5]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L44-R47) [[6]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L54-R57) [[7]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L70-R73) [[8]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L94-R97) [[9]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L129-R132) [[10]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L154-R157) [[11]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L177-R181) [[12]](diffhunk://#diff-b9f2800de28d172740b1d7b84eaf8e9d75b9aa286b7305a8be9981793357c2f6L194-R198)

**Documentation updates:**

* All code samples in documentation files (`README.md`, `docs/PROOF_GENERATION.md`, `docs/STREAMING.md`) were updated to use the new namespaces and imports, ensuring consistency and clarity for users. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R82) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R229) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R292-R295) [[5]](diffhunk://#diff-4101c3e48193c31c96050ba99d7e4471c092295868b62024a85dea2c086a47bdL18-R20) [[6]](diffhunk://#diff-4101c3e48193c31c96050ba99d7e4471c092295868b62024a85dea2c086a47bdR67-R70) [[7]](diffhunk://#diff-4101c3e48193c31c96050ba99d7e4471c092295868b62024a85dea2c086a47bdR157-R158) [[8]](diffhunk://#diff-4101c3e48193c31c96050ba99d7e4471c092295868b62024a85dea2c086a47bdL202-R212) [[9]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R14-R15) [[10]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R40-R41) [[11]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R96-R97) [[12]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R119-R120) [[13]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R143-R144) [[14]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R204-R206) [[15]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R226-R227) [[16]](diffhunk://#diff-e3a78f174b6158e6a8010604ef6ae184cfcc8f6667f8d80ec54644f82d1dd917R244-R245)

No functional changes were made to the core algorithms; all updates are structural and organizational, making the codebase easier to navigate and maintain.